### PR TITLE
Feature/add Loki logging configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,12 @@ SPRING_PROFILES_ACTIVE=docker
 DATABASE_SEEDING_ENABLED=true
 
 # ===============================
+# LOGGING & MONITORING
+# ===============================
+# URL del servicio Loki para envío de logs
+LOKI_URL=http://loki:3100/loki/api/v1/push
+
+# ===============================
 # JAVA/JVM OPTIONS (for development)
 # ===============================
 # Opciones JVM para debug y desarrollo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - PRODUCTS_API_KEY=${PRODUCTS_API_KEY:-your-secret-api-key-here}
       - APP_API_KEY=${APP_API_KEY:-your-secret-api-key-here}
       - DATABASE_SEEDING_ENABLED=${DATABASE_SEEDING_ENABLED:-true}
+      - LOKI_URL=${LOKI_URL:-http://loki:3100/loki/api/v1/push}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,7 +5,7 @@
     <!-- Loki Appender Configuration -->
     <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
         <http>
-            <url>http://java-product-api-loki-dev:3100/loki/api/v1/push</url>
+            <url>${LOKI_URL:-http://loki:3100/loki/api/v1/push}</url>
         </http>
         <format>
             <label>


### PR DESCRIPTION
This pull request introduces support for configuring the Loki logging service endpoint via environment variables, making log management more flexible and environment-agnostic. The changes ensure that the Loki URL can be set in `.env.example`, passed through Docker Compose, and referenced dynamically in the logging configuration.

**Logging and monitoring configuration:**

* Added `LOKI_URL` environment variable to `.env.example` to allow specifying the Loki logging service endpoint.
* Updated `docker-compose.yml` to pass the `LOKI_URL` environment variable to the application container, enabling dynamic configuration of the log destination.

**Application logging setup:**

* Modified `src/main/resources/logback-spring.xml` to use the `LOKI_URL` environment variable for the Loki appender, replacing the static URL with a configurable value.