### PR TITLE
Fix database URL in environment configuration for consistency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 # ===============================
 # DATABASE CONFIGURATION
 # ===============================
-SPRING_DATASOURCE_URL=jdbc:postgresql://java-product-api-postgres-dev:5432/inventoryapi
+SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-db:5432/inventoryapi
 SPRING_DATASOURCE_USERNAME=dev
 SPRING_DATASOURCE_PASSWORD=devpass123
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "8082:8080"  # Puerto diferente para evitar conflicto con product-api
     environment:
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-docker}
-      - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-jdbc:postgresql://java-product-api-postgres-dev:5432/inventoryapi}
+      - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL:-jdbc:postgresql://postgres-db:5432/inventoryapi}
       - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME:-dev}
       - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD:-devpass123}
       - EXTERNAL_PRODUCTS_SERVICE_BASE_URL=${EXTERNAL_PRODUCTS_SERVICE_BASE_URL:-http://java-product-api-app-dev:8080}


### PR DESCRIPTION
This pull request updates the database connection configuration to point to the correct PostgreSQL host. The changes ensure both local development and Docker environments use `postgres-db` as the database host, improving consistency and preventing connection issues.

**Configuration updates:**

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL9-R9): Changed the `SPRING_DATASOURCE_URL` to use `postgres-db` as the host instead of `java-product-api-postgres-dev`.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L10-R10): Updated the `SPRING_DATASOURCE_URL` environment variable for the service to use `postgres-db` as the host.